### PR TITLE
Feature/modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .terraform
 *.tfstate
 *.tfstate.backup
+access.json

--- a/gcp/live/global/storage.tf
+++ b/gcp/live/global/storage.tf
@@ -1,0 +1,27 @@
+provider "google" {
+    credentials = file("access.json")
+    project = "aerobic-bonus-270814"
+    region  = "europe-west2"
+}
+
+terraform {
+  backend "gcs" {
+    credentials = "access.json"
+    bucket  = "test_terraform_bucket"
+    prefix  = "terraform/state"
+  }
+}
+
+resource "google_storage_bucket" "first_test" {
+  name          = "test_terraform_bucket"
+  location      = "EU"
+  force_destroy = true
+
+  bucket_policy_only = true
+
+}
+
+
+
+
+

--- a/gcp/live/stage/services/webserver-cluster/main.tf
+++ b/gcp/live/stage/services/webserver-cluster/main.tf
@@ -5,28 +5,7 @@ provider "google" {
     zone    = "europe-west2-a"
 }
 
-terraform {
-  backend "gcs" {
-    credentials = "../../../global/access.json"
-    bucket  = "test_terraform_bucket"
-    prefix  = "terraform/stage/state"
-  }
+module "webserver_cluster" {
+  source = "../../../../modules/services/webserver-cluster"
 }
 
-resource "google_compute_instance" "vm_instance" {
-  name         = "terraform-instance"
-  machine_type = "f1-micro"
-
-  boot_disk {
-    initialize_params {
-      image = "debian-cloud/debian-9"
-    }
-  }
-
-  network_interface {
-    # A default network is created for all GCP projects
-    network       = "default"
-    access_config {
-    }
-  }
-}

--- a/gcp/live/stage/services/webserver-cluster/main.tf
+++ b/gcp/live/stage/services/webserver-cluster/main.tf
@@ -1,0 +1,32 @@
+provider "google" {
+    credentials = "../../../global/access.json"
+    project = "aerobic-bonus-270814"
+    region  = "europe-west2"
+    zone    = "europe-west2-a"
+}
+
+terraform {
+  backend "gcs" {
+    credentials = "../../../global/access.json"
+    bucket  = "test_terraform_bucket"
+    prefix  = "terraform/stage/state"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "terraform-instance"
+  machine_type = "f1-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network       = "default"
+    access_config {
+    }
+  }
+}

--- a/gcp/modules/services/webserver-cluster/main.tf
+++ b/gcp/modules/services/webserver-cluster/main.tf
@@ -1,0 +1,32 @@
+provider "google" {
+    credentials = "../../../global/access.json"
+    project = "aerobic-bonus-270814"
+    region  = "europe-west2"
+    zone    = "europe-west2-a"
+}
+
+terraform {
+  backend "gcs" {
+    credentials = "../../../global/access.json"
+    bucket  = "test_terraform_bucket"
+    prefix  = "terraform/stage/state"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "terraform-instance"
+  machine_type = "f1-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network       = "default"
+    access_config {
+    }
+  }
+}


### PR DESCRIPTION
```
`Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.webserver_cluster.google_compute_instance.vm_instance will be created
  + resource "google_compute_instance" "vm_instance" {
      + can_ip_forward       = false
      + cpu_platform         = (known after apply)
      + current_status       = (known after apply)
      + deletion_protection  = false
      + guest_accelerator    = (known after apply)
      + id                   = (known after apply)
      + instance_id          = (known after apply)
      + label_fingerprint    = (known after apply)
      + machine_type         = "f1-micro"
      + metadata_fingerprint = (known after apply)
      + min_cpu_platform     = (known after apply)
      + name                 = "terraform-instance"
      + project              = (known after apply)
      + self_link            = (known after apply)
      + tags_fingerprint     = (known after apply)
      + zone                 = (known after apply)

      + boot_disk {
          + auto_delete                = true
          + device_name                = (known after apply)
          + disk_encryption_key_sha256 = (known after apply)
          + kms_key_self_link          = (known after apply)
          + mode                       = "READ_WRITE"
          + source                     = (known after apply)

          + initialize_params {
              + image  = "debian-cloud/debian-9"
              + labels = (known after apply)
              + size   = (known after apply)
              + type   = (known after apply)
            }
        }

      + network_interface {
          + name               = (known after apply)
          + network            = "default"
          + network_ip         = (known after apply)
          + subnetwork         = (known after apply)
          + subnetwork_project = (known after apply)

          + access_config {
              + nat_ip       = (known after apply)
              + network_tier = (known after apply)
            }
        }

      + scheduling {
          + automatic_restart   = (known after apply)
          + on_host_maintenance = (known after apply)
          + preemptible         = (known after apply)

          + node_affinities {
              + key      = (known after apply)
              + operator = (known after apply)
              + values   = (known after apply)
            }
        }
    }`
```